### PR TITLE
fix: Ensure filter button text is visible in light theme

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2402,6 +2402,16 @@ section {
 .filter__btn span {
   position: relative;
   z-index: 1;
+  color: inherit;
+}
+
+/* Ensure non-active filter buttons have visible text */
+.filter__btn:not(.filter__btn--active) {
+  color: #334155 !important;
+}
+
+.filter__btn:not(.filter__btn--active) span {
+  color: #334155;
 }
 
 .filter__btn:hover {


### PR DESCRIPTION
Add explicit color styling to non-active filter buttons to fix visibility issue where text appeared white on light background.

https://claude.ai/code/session_013FsPf4Em6nLsjebWyBH3vk