### PR TITLE
feat: Rename AI Assistant section to AI & Automation

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
                     <li><a href="#intro" class="sidebar__link sidebar__link--active">Intro</a></li>
                     <li><a href="#about" class="sidebar__link">About Me</a></li>
                     <li><a href="#portfolio" class="sidebar__link">Portfolio</a></li>
-                    <li><a href="#ai-assistant" class="sidebar__link">AI Assistant</a></li>
+                    <li><a href="#ai-assistant" class="sidebar__link">AI & Automation</a></li>
                     <li><a href="#experience" class="sidebar__link">Resume</a></li>
                     <li><a href="#contact" class="sidebar__link">Contact</a></li>
                 </ul>
@@ -766,25 +766,29 @@
                 </div>
             </section>
 
-            <!-- AI Assistant Section -->
+            <!-- AI & Automation Section -->
             <section id="ai-assistant" class="ai-assistant section--alt">
                 <div class="container">
-                    <h2 class="section__title animate-on-scroll">AI Assistant Demo</h2>
+                    <h2 class="section__title animate-on-scroll">AI & Automation</h2>
                     <div class="ai-assistant__content">
                         <div class="ai-assistant__intro animate-on-scroll" data-delay="100">
-                            <h3>End-to-End LLM Application</h3>
+                            <h3>AI-Powered Development & LLM Integration</h3>
                             <p class="ai-assistant__lead">
-                                This project demonstrates ability to ship LLM-based tools end-to-end: prompt engineering, API integration, and production UX.
-                                Relevant to internal chatbots, ops assistants, and AI-augmented workflows.
+                                Leveraging AI tools like Claude Code and Cursor for rapid development, combined with end-to-end LLM application building:
+                                prompt engineering, API integration, and production deployment.
                             </p>
                             <div class="ai-assistant__features">
                                 <div class="feature__item">
+                                    <i class="ph-code"></i>
+                                    <span>AI-Assisted Dev</span>
+                                </div>
+                                <div class="feature__item">
                                     <i class="ph-robot"></i>
-                                    <span>Prompt Design</span>
+                                    <span>Prompt Engineering</span>
                                 </div>
                                 <div class="feature__item">
                                     <i class="ph-plugs-connected"></i>
-                                    <span>API Integration</span>
+                                    <span>LLM Integration</span>
                                 </div>
                                 <div class="feature__item">
                                     <i class="ph-rocket-launch"></i>


### PR DESCRIPTION
- Update sidebar navigation link text
- Update section title to "AI & Automation"
- Expand intro to cover AI-assisted development (Claude Code, Cursor)
- Add AI-Assisted Dev feature badge

https://claude.ai/code/session_013FsPf4Em6nLsjebWyBH3vk